### PR TITLE
Let's Encrypt, migrating to ACMEv2

### DIFF
--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   minigrid:
-    image: selcolumbia/minigrid-server:0.3.6
+    image: selcolumbia/minigrid-server:0.3.7
     command: ./prod/run.sh --db_host=db --redis_url=redis://redis:6379/0 --minigrid-website-url=https://www.example.com
     depends_on:
       - redis

--- a/prod/install.sh
+++ b/prod/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Minigrid Server installer for version 0.3.6
+# Minigrid Server installer for version 0.3.7
 set -e
 
 # Do you have docker installed?
@@ -108,8 +108,8 @@ $SUDO openssl dhparam -out /etc/letsencrypt/live/$LETSENCRYPT_DIR/dhparam.pem 20
 printf "========================================\n"
 printf " Generating configuration               \n"
 printf "========================================\n"
-$CURL -L https://raw.githubusercontent.com/SEL-Columbia/minigrid-server/0.3.6/prod/docker-compose.yml > docker-compose.yml
-$CURL -L https://raw.githubusercontent.com/SEL-Columbia/minigrid-server/0.3.6/prod/nginx.conf > nginx.conf
+$CURL -L https://raw.githubusercontent.com/SEL-Columbia/minigrid-server/0.3.7/prod/docker-compose.yml > docker-compose.yml
+$CURL -L https://raw.githubusercontent.com/SEL-Columbia/minigrid-server/0.3.7/prod/nginx.conf > nginx.conf
 
 sed -i s/www.example.com/$LETSENCRYPT_DIR/g docker-compose.yml
 sed -i s/www.example.com/$LETSENCRYPT_DIR/g nginx.conf
@@ -154,7 +154,7 @@ CRON_CMD_1="mkdir -p /tmp/letsencrypt && "\
 " -v /var/lib/letsencrypt:/var/lib/letsencrypt:Z"\
 " -v /tmp:/tmp:Z"\
 " -v /var/log/letsencrypt:/var/log/letsencrypt:Z"\
-" quay.io/letsencrypt/letsencrypt renew --quiet --webroot --webroot-path /tmp/letsencrypt;"\
+" certbot/certbot:latest renew --quiet --webroot --webroot-path /tmp/letsencrypt;"\
 " docker restart $NGINX_CONTAINER_NAME"
 # https://certbot.eff.org/#ubuntuxenial-nginx recommends running this twice a day on random minute within the hour
 CRON_JOB_1="00 01,13 * * * sleep \$(expr \$RANDOM \% 59 \* 60); $CRON_CMD_1"


### PR DESCRIPTION
Let's Encrypt, migrating to ACMEv2

move from quay.io/letsencrypt/letsencrypt to certbot/certbot:latest

fixes #97 